### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ This is a direct port of [Anthropic's filesystem editing tools](https://github.c
 
 I recommend using this server along with [mcp-server-commands](https://github.com/g0t4/mcp-server-commands)
 
+<a href="https://glama.ai/mcp/servers/lnfcd9is5i"><img width="380" height="200" src="https://glama.ai/mcp/servers/lnfcd9is5i/badge" alt="mcp-editor MCP server" /></a>
+
 ### ***WARNING: This MCP server has NO access controls and relies entirely on your client's approval mechanisms. Use at your own risk. DO NOT automatically approve write operations, doing so basically gives the LLM permission to destroy your computer.***
 ### ***WARNING: This MCP server is NOT actively maintained, and is provided for reference (for example creating your own MCP server with proper access controls). I may update it occasionally.***
 


### PR DESCRIPTION
This PR adds a badge for the [mcp-editor](https://glama.ai/mcp/servers/lnfcd9is5i) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/lnfcd9is5i"><img width="380" height="200" src="https://glama.ai/mcp/servers/lnfcd9is5i/badge" alt="mcp-editor MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.